### PR TITLE
Make the syslog string RFC compliant and switch to key=value string

### DIFF
--- a/drivers/Syslog.groovy
+++ b/drivers/Syslog.groovy
@@ -16,6 +16,9 @@
 
 /* Notes
 
+2024-01-29 - rmonk
+  - Tweaked the log string to be RFC5424 compliant
+  - Changed the logging init delay to 10 seconds to try and get it to properly start on boot
 2020-08-18 - staylorx
   - A couple of dumb coding errors, and still trying to sort out TCP
 2020-08-18 - staylorx


### PR DESCRIPTION
I have added the facility/priority field needed for the messages to be RFC5424 compliant, and switched away from structured data format to plain key="value" which is automatically understood by things such as Splunk and is readily human readable.  This makes the logs work extremely well at least using rsyslog as a receiver and Splunk as a parser, with no additional configuration needed.